### PR TITLE
Dismiss on scroll and customizable consent hook

### DIFF
--- a/cookieconsent.js
+++ b/cookieconsent.js
@@ -21,8 +21,8 @@
 
   // No point going further if they've already dismissed.
   if (document.cookie.indexOf(DISMISSED_COOKIE) > -1) {
-    if (window[OPTIONS_VARIABLE] && window[OPTIONS_VARIABLE]['consent_hook']) {
-      window[OPTIONS_VARIABLE]['consent_hook']();
+    if (window[OPTIONS_VARIABLE] && window[OPTIONS_VARIABLE]['consentHook']) {
+      window[OPTIONS_VARIABLE]['consentHook']();
     }
     return;
   }
@@ -250,8 +250,11 @@
         '</div>',
         '</div>'
       ],
-      consent_hook: null, // hook function called on dismiss or if already dismissed
+      consentHook: null, // hook function called on dismiss or if already dismissed
+      dismissOnScroll: false, // dismiss when the user scroll down
+      dismissOnScrollRange: 20 // dismiss when the user scroll down after 20 pixels
     },
+    onScrollY: 0,
 
     init: function () {
       var options = window[OPTIONS_VARIABLE];
@@ -264,6 +267,15 @@
         this.loadTheme(this.render);
       } else {
         this.render();
+      }
+
+      // enable dismiss on scroll listener
+      if(this.options.dismissOnScroll) {
+        window.addEventListener('load', function(){
+
+          cookieconsent.onScrollY = window.pageYOffset;
+          window.addEventListener('scroll', cookieconsent.onScroll);
+        });
       }
     },
 
@@ -330,12 +342,21 @@
     },
 
     dismiss: function (evt) {
-      evt.preventDefault && evt.preventDefault();
-      evt.returnValue = false;
+      if(evt) {
+        evt.preventDefault && evt.preventDefault();
+        evt.returnValue = false;
+      }
       this.setDismissedCookie();
       this.container.removeChild(this.element);
-      if(this.options.consent_hook) {
-        this.options.consent_hook();
+      if(this.options.consentHook) {
+        this.options.consentHook();
+      }
+    },
+
+    onScroll: function (evt) {
+      if (Math.abs(window.pageYOffset - cookieconsent.onScrollY) > cookieconsent.options.dismissOnScrollRange) {
+        cookieconsent.dismiss(null);
+        window.removeEventListener('scroll', cookieconsent.onScroll);
       }
     },
 

--- a/cookieconsent.js
+++ b/cookieconsent.js
@@ -21,6 +21,9 @@
 
   // No point going further if they've already dismissed.
   if (document.cookie.indexOf(DISMISSED_COOKIE) > -1) {
+    if (window[OPTIONS_VARIABLE] && window[OPTIONS_VARIABLE]['consent_hook']) {
+      window[OPTIONS_VARIABLE]['consent_hook']();
+    }
     return;
   }
 
@@ -246,7 +249,8 @@
         '<a class="cc_logo" target="_blank" href="http://silktide.com/cookieconsent">Cookie Consent plugin for the EU cookie law</a>',
         '</div>',
         '</div>'
-      ]
+      ],
+      consent_hook: null, // hook function called on dismiss or if already dismissed
     },
 
     init: function () {
@@ -330,6 +334,9 @@
       evt.returnValue = false;
       this.setDismissedCookie();
       this.container.removeChild(this.element);
+      if(this.options.consent_hook) {
+        this.options.consent_hook();
+      }
     },
 
     setDismissedCookie: function () {

--- a/example.hook.html
+++ b/example.hook.html
@@ -19,7 +19,8 @@
     window.cookieconsent_options = {
         learnMore: 'more info',
         theme: 'styles/dark-top.css',
-        consent_hook: function() { alert('consent hook example'); }
+        consentHook: function() { alert('consent hook example'); },
+        dismissOnScroll: true
     }
 </script>
 <script type="text/javascript" src="cookieconsent.js"></script>

--- a/example.hook.html
+++ b/example.hook.html
@@ -1,0 +1,26 @@
+<!--
+    An example of how to use cookie consent only using the local files
+-->
+<html>
+<head>
+    <title>Cookie Consent</title>
+
+</head>
+<body>
+    <h1>Cookie Consent example page.</h1>
+
+    <div class="cookie_container"></div>
+
+    <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
+</body>
+
+
+<script>
+    window.cookieconsent_options = {
+        learnMore: 'more info',
+        theme: 'styles/dark-top.css',
+        consent_hook: function() { alert('consent hook example'); }
+    }
+</script>
+<script type="text/javascript" src="cookieconsent.js"></script>
+</html>


### PR DESCRIPTION
I've added two features to your script.

1) a configurable hook launched when the user dismiss the popup or if it is already dismissed. This is usefull when you want to block third party cookies.

2) (optional) dismiss the popup when the user scrolls the page down. In some country this behaviour is allowed by the law.