### PR TITLE
Add onDismiss callback

### DIFF
--- a/cookieconsent.js
+++ b/cookieconsent.js
@@ -333,6 +333,9 @@
       evt.returnValue = false;
       this.setDismissedCookie();
       this.container.removeChild(this.element);
+      if(window[OPTIONS_VARIABLE].onDismiss != undefined){
+      	window[OPTIONS_VARIABLE].onDismiss();
+      }
     },
 
     setDismissedCookie: function () {


### PR DESCRIPTION
We needed a callback when the cookie consent was given.

I've added a callback that could be used like this:
```js
window.cookieconsent_options = {
	"message": "This website uses cookies to ensure you get the best experience on our website",
	"dismiss": "Got it!",
	"learnMore": "More info",
	"link": "https://www.ing.nl/de-ing/de-ing-en-cookies/index.html",
	"theme": "light-bottom",
	"onDismiss": function(){
		console.log('Now add cookie related stuff');
	}
};
```