### PR TITLE
Fontawesome works inside buttons

### DIFF
--- a/src/cookieconsent.js
+++ b/src/cookieconsent.js
@@ -743,6 +743,7 @@
 
     function handleButtonClick(event) {
       var targ = event.target;
+      targ = util.hasClass(targ, 'cc-btn') ? targ : targ.parentNode;
       if (util.hasClass(targ, 'cc-btn')) {
 
         var matches = targ.className.match(new RegExp("\\bcc-(" + __allowedStatuses.join('|') + ")\\b"));


### PR DESCRIPTION
However, my solution is not even close to pretty. I'm short on time and not that savy with vanilla-js, so I don't really know how to traverse the `event.target` properly in order to find the element that has the `cc-btn` class. I _think_ the click events just should be attached directly to the btns instead and the use the `event.currentTarget` props instead. 

Well, hopes this is hlping someone.