### PR TITLE
Add jsDelivr links

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,12 @@ Or through [Bower](https://bower.io/):
 bower install cookieconsent
 ```
 
+Or via a jsDelivr:
+
+```html
+<script src="https://cdn.jsdelivr.net/npm/cookieconsent@3/build/cookieconsent.min.js"></script>
+```
+
 ## Documentation 
 
 See our [full documentation](https://cookieconsent.insites.com/documentation/).


### PR DESCRIPTION
I added [jsDelivr CDN links](https://www.jsdelivr.com/package/npm/cookieconsent) to your readme to make it easier to use. jsDelivr is the fastest opensource CDN available and built specifically for production usage. 