### PR TITLE
Fixes Flex Layout Issues IE10/IE11

### DIFF
--- a/src/styles/layout.css
+++ b/src/styles/layout.css
@@ -42,7 +42,8 @@
 }
 
 .cc-banner .cc-message {
-  flex: 1;
+  flex: auto;
+  max-width: 100%;
 }
 
 /* COMPLIANCE BOX */

--- a/src/styles/layout.css
+++ b/src/styles/layout.css
@@ -42,7 +42,8 @@
 }
 
 .cc-banner .cc-message {
-  flex: auto;
+  display: block;
+  flex: 1 1 auto;
   max-width: 100%;
 }
 

--- a/src/styles/media.css
+++ b/src/styles/media.css
@@ -17,7 +17,7 @@
   .cc-window.cc-banner,.cc-window.cc-right,.cc-window.cc-left {left:0;right:0;}
 
   .cc-window.cc-banner {flex-direction: column;}
-  .cc-window.cc-banner .cc-compliance {flex: auto;}
+  .cc-window.cc-banner .cc-compliance {flex: 1 1 auto;}
   .cc-window.cc-floating {max-width: none;}
   .cc-window .cc-message {margin-bottom: 1em}
   .cc-window.cc-banner {align-items: unset;}

--- a/src/styles/media.css
+++ b/src/styles/media.css
@@ -17,7 +17,7 @@
   .cc-window.cc-banner,.cc-window.cc-right,.cc-window.cc-left {left:0;right:0;}
 
   .cc-window.cc-banner {flex-direction: column;}
-  .cc-window.cc-banner .cc-compliance {flex: 1}
+  .cc-window.cc-banner .cc-compliance {flex: auto;}
   .cc-window.cc-floating {max-width: none;}
   .cc-window .cc-message {margin-bottom: 1em}
   .cc-window.cc-banner {align-items: unset;}


### PR DESCRIPTION
This fixes the issues with IE10/IE11 and the flex layout on smaller screen sizes a/o during shrinking of the window <=414px <=736px and <=900px. The issue occured for me on the bottom (overlay) banner. I previously opened an issue - please see also #231 for more information and a screenshot. I also tested my changes on all major browsers that I'm able to test by myself (Chrome, IE10, IE11, FF and Edge) and the changes seem to work on all of them (incl. opt-in and opt-out buttons). However, I did no full test over all banner types and on Apple browsers, so a bit of testing will be necessary before merging the changes ;). 

Edited to reflect IE 10 changes which required additional modifications :(