### PR TITLE
Add dismissOnWindowClick feature

### DIFF
--- a/src/cookieconsent.js
+++ b/src/cookieconsent.js
@@ -116,7 +116,7 @@
 
     // used to change color on highlight
     getLuminance: function(hex) {
-      var num = parseInt(this.normaliseHex(hex), 16), 
+      var num = parseInt(this.normaliseHex(hex), 16),
           amt = 38,
           R = (num >> 16) + amt,
           B = (num >> 8 & 0x00FF) + amt,
@@ -312,13 +312,16 @@
       // set value as time in milliseconds to autodismiss after set time
       dismissOnTimeout: false,
 
+      // set value as click anything on the page
+      dismissOnWindowClick: false,
+
       // The application automatically decide whether the popup should open.
       // Set this to false to prevent this from happening and to allow you to control the behaviour yourself
       autoOpen: true,
 
       // By default the created HTML is automatically appended to the container (which defaults to <body>). You can prevent this behaviour
       // by setting this to false, but if you do, you must attach the `element` yourself, which is a public property of the popup instance:
-      // 
+      //
       //     var instance = cookieconsent.factory(options);
       //     document.body.appendChild(instance.element);
       //
@@ -415,6 +418,11 @@
       if (this.onWindowScroll) {
         window.removeEventListener('scroll', this.onWindowScroll);
         this.onWindowScroll = null;
+      }
+
+      if (this.onWindowClick) {
+        window.removeEventListener('click', this.onWindowClick);
+        this.onWindowClick = null;
       }
 
       if (this.onMouseMove) {
@@ -817,8 +825,8 @@
             'border-color: ' + button.border,
             'background-color: ' + button.background
           ];
-          
-          if(button.background != 'transparent') 
+
+          if(button.background != 'transparent')
             colorStyles[prefix + ' .cc-btn:hover, ' + prefix + ' .cc-btn:focus'] = [
               'background-color: ' + getHoverColour(button.background)
             ];
@@ -897,6 +905,7 @@
 
     function applyAutoDismiss() {
       var setStatus = this.setStatus.bind(this);
+      var close = this.close.bind(this);
 
       var delay = this.options.dismissOnTimeout;
       if (typeof delay == 'number' && delay >= 0) {
@@ -918,6 +927,18 @@
 
         this.onWindowScroll = onWindowScroll;
         window.addEventListener('scroll', onWindowScroll);
+      }
+
+      var windowClick = this.options.dismissOnWindowClick;
+      if (windowClick) {
+        var onWindowClick = function(evt) {
+          setStatus(cc.status.dismiss);
+          close(true);
+          window.removeEventListener('click', onWindowClick);
+          this.onWindowClick = null;
+        };
+        this.onWindowClick = onWindowClick;
+        window.addEventListener('click', onWindowClick);
       }
     }
 


### PR DESCRIPTION
Hi there,

Just want to request a feature to allow dismissing the consent whenever user clicks anything on the page.

This requirement seems a little strange to my understanding, but in my case, my UX explicitly want this behavior in order to reduce the friction. (We want to each of our clients to be able to turn on cookie consent, which means almost each website hosted under our guest domain will show the same banner to the same end user...) I'm not sure if this is a common requirement, but the idea & implementation are similar to dismissOnTimeout & dismissOnScroll.

This feature is turned off by default. When `dismissOnWindowClick == true`, click anything on the page will dismiss the consent.