### PR TITLE
Changed consent status to consider opt-in and opt-out status for dimiss event

### DIFF
--- a/src/cookieconsent.js
+++ b/src/cookieconsent.js
@@ -556,7 +556,10 @@
     // returns true if the cookie indicates that consent has been given
     CookiePopup.prototype.hasConsented = function(options) {
       var val = this.getStatus();
-      return val == cc.status.allow || val == cc.status.dismiss;
+      if (this.type == "opt-out") {
+        return val == cc.status.allow || val == cc.status.dismiss;
+      }
+      return val == cc.status.allow;
     };
 
     // opens the popup if no answer has been given

--- a/src/cookieconsent.js
+++ b/src/cookieconsent.js
@@ -556,10 +556,10 @@
     // returns true if the cookie indicates that consent has been given
     CookiePopup.prototype.hasConsented = function(options) {
       var val = this.getStatus();
-      if (this.type == "opt-out") {
-        return val == cc.status.allow || val == cc.status.dismiss;
+      if (this.type == "opt-in") {
+        return val == cc.status.allow
       }
-      return val == cc.status.allow;
+      return val == cc.status.allow || val == cc.status.dismiss;
     };
 
     // opens the popup if no answer has been given

--- a/src/cookieconsent.js
+++ b/src/cookieconsent.js
@@ -116,7 +116,7 @@
 
     // used to change color on highlight
     getLuminance: function(hex) {
-      var num = parseInt(this.normaliseHex(hex), 16), 
+      var num = parseInt(this.normaliseHex(hex), 16),
           amt = 38,
           R = (num >> 16) + amt,
           B = (num >> 8 & 0x00FF) + amt,
@@ -318,7 +318,7 @@
 
       // By default the created HTML is automatically appended to the container (which defaults to <body>). You can prevent this behaviour
       // by setting this to false, but if you do, you must attach the `element` yourself, which is a public property of the popup instance:
-      // 
+      //
       //     var instance = cookieconsent.factory(options);
       //     document.body.appendChild(instance.element);
       //
@@ -556,7 +556,8 @@
     // returns true if the cookie indicates that consent has been given
     CookiePopup.prototype.hasConsented = function(options) {
       var val = this.getStatus();
-      if (this.type == "opt-in") {
+      var type = this.options.type;
+      if (type == "opt-in") {
         return val == cc.status.allow
       }
       return val == cc.status.allow || val == cc.status.dismiss;
@@ -820,8 +821,8 @@
             'border-color: ' + button.border,
             'background-color: ' + button.background
           ];
-          
-          if(button.background != 'transparent') 
+
+          if(button.background != 'transparent')
             colorStyles[prefix + ' .cc-btn:hover, ' + prefix + ' .cc-btn:focus'] = [
               'background-color: ' + getHoverColour(button.background)
             ];


### PR DESCRIPTION
As soon as you like to use opt-in with the cookieconsent script the hasConcented() function doesn't work as expected.

*Behavior*
hasConsented() returns true, if status is dismiss. This is wrong because opt-in can only be true if the status is allowed.