### PR TITLE
Fix getCookie() when more than 1 cookie is found

### DIFF
--- a/src/cookieconsent.js
+++ b/src/cookieconsent.js
@@ -33,7 +33,7 @@
     getCookie: function(name) {
       var value = '; ' + document.cookie;
       var parts = value.split('; ' + name + '=');
-      return parts.length != 2 ?
+      return parts.length < 2 ?
         undefined : parts.pop().split(';').shift();
     },
 


### PR DESCRIPTION
getCookie() is returning undefined when more than 1 Cookie Consent
cookie is found. This can occur by setting a value to cookie.domain
after the Cookie Consent plugin was deployed to production.

For example, the Cookie Consent plugin was setting the domain to www.eclipse.org and we decided to change it to .eclipse.org.

This change is causing some users to view the cookie consent banner on every page because getCookie() is currently returning undefined instead of the value of the first cookie.

Signed-off-by: Christopher Guindon <chris.guindon@eclipse-foundation.org>