### PR TITLE
Spacing between message and button

### DIFF
--- a/src/styles/layout.css
+++ b/src/styles/layout.css
@@ -43,6 +43,7 @@
 
 .cc-banner .cc-message {
   flex: 1;
+  margin-right: 1em;
 }
 
 /* COMPLIANCE BOX */

--- a/src/styles/media.css
+++ b/src/styles/media.css
@@ -21,6 +21,7 @@
   .cc-window.cc-floating {max-width: none;}
   .cc-window .cc-message {margin-bottom: 1em}
   .cc-window.cc-banner {align-items: unset;}
+  .cc-window.cc-banner .cc-message {margin-right: 0;}
 }
 
 /* iPhone 6 */


### PR DESCRIPTION
The cookie message could get too close to the dismiss button when the cookieconsent is displayed as a banner. I added some spacing to prevent this.

Before:
![screenshot-2018-6-8 demo 1 - themes](https://user-images.githubusercontent.com/10660618/41159199-f3a5b170-6b2b-11e8-97cc-5f58530f1805.png)

After:
![screenshot-2018-6-8 demo 1 - themes 1](https://user-images.githubusercontent.com/10660618/41159388-ab9681c4-6b2c-11e8-8c6e-5d4306128e6c.png)

