### PR TITLE
Added a onNoCookieLaw callback that is called when the country has no cookie law

### DIFF
--- a/examples/example-7-javascript-api.html
+++ b/examples/example-7-javascript-api.html
@@ -83,6 +83,9 @@
     onRevokeChoice: function() {
       log('<em>onRevokeChoice()</em> called');
     },
+    onNoCookieLaw: function (countryCode, country) {
+      log('<em>onNoCookieLaw()</em> called with countryCode <em>'+countryCode+'</em>');
+    },
   }, function (popup) {
     p = popup;
   }, function (err) {

--- a/src/cookieconsent.js
+++ b/src/cookieconsent.js
@@ -201,6 +201,7 @@
       onInitialise: function(status) {},
       onStatusChange: function(status, chosenBefore) {},
       onRevokeChoice: function() {},
+      onNoCookieLaw: function(countryCode, country) {},
 
       // each item defines the inner text for the element that it references
       content: {
@@ -1416,6 +1417,9 @@
       if (!country.hasLaw) {
         // The country has no cookie law
         options.enabled = false;
+        if (typeof options.onNoCookieLaw === 'function') {
+          options.onNoCookieLaw(countryCode, country);
+        }
       }
 
       if (this.options.regionalLaw) {


### PR DESCRIPTION
Solves #393 

Not sure about this. I think it could also be good if the `onInitialise` was always called, even if the popup was disabled.

The problem I'm solving is that I need to run a function to set up Google Analytics, either when the user consents to the cookie (in the EU), or when the country has no cookie laws (e.g. US.)